### PR TITLE
Devoncarew more tests

### DIFF
--- a/test/all.dart
+++ b/test/all.dart
@@ -1,0 +1,13 @@
+// Copyright (c) 2014, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+library all_test;
+
+import 'benchmark_harness_test.dart' as benchmark_harness_test;
+import 'result_emitter_test.dart' as result_emitter_test;
+
+void main() {
+  benchmark_harness_test.main();
+  result_emitter_test.main();
+}

--- a/test/drone.sh
+++ b/test/drone.sh
@@ -1,12 +1,11 @@
 # get the packages
 pub install
 
-# analyzer the code
+# analyze the code
 dartanalyzer example/Template.dart
 dartanalyzer lib/benchmark_harness.dart
+dartanalyzer test/all.dart
 dartanalyzer test/benchmark_harness_test.dart
-dartanalyzer test/result_emitter_test.dart
 
 # run the tests
-dart test/benchmark_harness_test.dart
-dart test/result_emitter_test.dart
+dart test/all.dart

--- a/test/result_emitter_test.dart
+++ b/test/result_emitter_test.dart
@@ -19,6 +19,9 @@ class MockResultEmitter extends Mock implements ScoreEmitter {
   void fakeEmit(String name, double value) {
     hasEmitted = true;
   }
+
+  // Added to quiet an analyzer warning.
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
 // Create a new benchmark which has an emitter.


### PR DESCRIPTION
- add an `all.dart` test suite, to call the two other test libraries
- fix an analysis issue in the emitter test suite, so we analyze clean
- add a `drone.sh` script, which can be invoked by a build / CI system to test the library
