### PR TITLE
Update benchmark_base.dart

### DIFF
--- a/lib/src/benchmark_base.dart
+++ b/lib/src/benchmark_base.dart
@@ -46,7 +46,7 @@ class BenchmarkBase {
     while (elapsed < minimumMicros) {
       f();
       elapsed = watch.elapsedMicroseconds;
-      iter++;
+      iter+=10; // each f() runs the benchmarking fn 10 times
     }
     return elapsed / iter;
   }


### PR DESCRIPTION
bug: all results (in microseconds) are 10 times higher than they should be