### PR TITLE
Added some optional named parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ packages
 pubspec.lock
 *.sublime-workspace
 *.sublime-project
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+## 1.1.0
+
+  * Added `iterations` optional named argument to the `exercise` and `warmup` 
+    methods which controls how many times `run` is called.
+  * Added `maxIterations` optional named argument to the `measureFor` method.
+    If supplied then the benchmark will exit immediately once `f` has
+    been called that many times, regardless of the `minimumMillis` setting.
+  * Added various optional named arguments to the `measure` method.
+    * `minimumWarmupMillis`: The minimum amount of time to warmup for.
+    * `minimumBenchmarkMillis`: The minimum amount of time to run the benchmark.
+    * `maxWarmupIterations`: The maximum number of times to call `warmup`.
+    * `maxExerciseIterations`: The maximum number of times to call `exercise`. 
+    * `runsPerWarmup`: How many times `run` should be called by `warmup`.
+    * `runsPerExercise`: How many times `run` should be called by `exercise`.

--- a/lib/src/benchmark_base.dart
+++ b/lib/src/benchmark_base.dart
@@ -7,14 +7,13 @@ class BenchmarkBase {
   final ScoreEmitter emitter;
 
   /// Empty constructor.
-  const BenchmarkBase(String name,
-      { ScoreEmitter emitter: const PrintEmitter() })
+  const BenchmarkBase(String name, {ScoreEmitter emitter: const PrintEmitter()})
       : this.name = name,
         this.emitter = emitter;
 
   /// The benchmark code.
   /// This function is not used if both [warmup] and [exercise] are overwritten.
-  void run() { }
+  void run() {}
 
   /// Runs a short version of the benchmark. By default invokes [run] once.
   void warmup({int iterations: 1}) {
@@ -31,10 +30,10 @@ class BenchmarkBase {
   }
 
   /// Not measured setup code executed prior to the benchmark runs.
-  void setup() { }
+  void setup() {}
 
   /// Not measured teardown code executed after the benchark runs.
-  void teardown() { }
+  void teardown() {}
 
   /// Measures the score for this benchmark by executing it repeately until
   /// either the [minimumMillis] or [maxIterations] has been reached.
@@ -62,19 +61,19 @@ class BenchmarkBase {
   /// result. Then runs the benchmark for either [minimumBenchmarkMillis] or
   /// [maxExerciseIterations] * [runsPerExercise] iterations and returns the
   /// result.
-  double measure(
-      {int minimumWarmupMillis: 100, int minimumBenchmarkMillis: 2000,
-      int maxWarmupIterations: null, int runsPerWarmup: 1,
-      int maxExerciseIterations: null, int runsPerExercise: 10}) {
+  double measure({int minimumWarmupMillis: 100,
+      int minimumBenchmarkMillis: 2000, int maxWarmupIterations: null,
+      int runsPerWarmup: 1, int maxExerciseIterations: null,
+      int runsPerExercise: 10}) {
     setup();
     // Run the warmup.
-    measureFor(
-        () { this.warmup(iterations: runsPerWarmup); },
-        minimumWarmupMillis, maxIterations: maxWarmupIterations);
+    measureFor(() {
+      this.warmup(iterations: runsPerWarmup);
+    }, minimumWarmupMillis, maxIterations: maxWarmupIterations);
     // Run the benchmark.
-    double result = measureFor(
-        () {this.exercise(iterations: runsPerExercise); },
-        minimumBenchmarkMillis, maxIterations: maxExerciseIterations);
+    double result = measureFor(() {
+      this.exercise(iterations: runsPerExercise);
+    }, minimumBenchmarkMillis, maxIterations: maxExerciseIterations);
     teardown();
     return result;
   }
@@ -82,5 +81,4 @@ class BenchmarkBase {
   void report() {
     emitter.emit(name, measure());
   }
-
 }

--- a/lib/src/benchmark_base.dart
+++ b/lib/src/benchmark_base.dart
@@ -6,37 +6,40 @@ class BenchmarkBase {
   final String name;
   final ScoreEmitter emitter;
 
-  // Empty constructor.
+  /// Empty constructor.
   const BenchmarkBase(String name,
       { ScoreEmitter emitter: const PrintEmitter() })
       : this.name = name,
         this.emitter = emitter;
 
-  // The benchmark code.
-  // This function is not used, if both [warmup] and [exercise] are overwritten.
+  /// The benchmark code.
+  /// This function is not used if both [warmup] and [exercise] are overwritten.
   void run() { }
 
-  // Runs a short version of the benchmark. By default invokes [run] once.
-  void warmup() {
-    run();
-  }
-
-  // Exercices the benchmark. By default invokes [run] 10 times.
-  void exercise() {
-    for (int i = 0; i < 10; i++) {
+  /// Runs a short version of the benchmark. By default invokes [run] once.
+  void warmup({int iterations: 1}) {
+    for (int i = 0; i < iterations; i++) {
       run();
     }
   }
 
-  // Not measured setup code executed prior to the benchmark runs.
+  /// Exercises the benchmark. By default invokes [run] 10 times.
+  void exercise({int iterations: 10}) {
+    for (int i = 0; i < iterations; i++) {
+      run();
+    }
+  }
+
+  /// Not measured setup code executed prior to the benchmark runs.
   void setup() { }
 
-  // Not measures teardown code executed after the benchark runs.
+  /// Not measured teardown code executed after the benchark runs.
   void teardown() { }
 
-  // Measures the score for this benchmark by executing it repeately until
-  // time minimum has been reached.
-  static double measureFor(Function f, int minimumMillis) {
+  /// Measures the score for this benchmark by executing it repeately until
+  /// either the [minimumMillis] or [maxIterations] has been reached.
+  static double measureFor(Function f, int minimumMillis,
+      {int maxIterations: null}) {
     int minimumMicros = minimumMillis * 1000;
     int time = 0;
     int iter = 0;
@@ -44,6 +47,7 @@ class BenchmarkBase {
     watch.start();
     int elapsed = 0;
     while (elapsed < minimumMicros) {
+      if (maxIterations != null && iter >= maxIterations) break;
       f();
       elapsed = watch.elapsedMicroseconds;
       iter++;
@@ -51,13 +55,26 @@ class BenchmarkBase {
     return elapsed / iter;
   }
 
-  // Measures the score for the benchmark and returns it.
-  double measure() {
+  /// Measures the score for the benchmark and returns it.
+  ///
+  /// Performs a warmup for either [minimumWarmupMillis] or
+  /// [maxWarmupIterations] * [runsPerWarmup] iterations, and discards the
+  /// result. Then runs the benchmark for either [minimumBenchmarkMillis] or
+  /// [maxExerciseIterations] * [runsPerExercise] iterations and returns the
+  /// result.
+  double measure(
+      {int minimumWarmupMillis: 100, int minimumBenchmarkMillis: 2000,
+      int maxWarmupIterations: null, int runsPerWarmup: 1,
+      int maxExerciseIterations: null, int runsPerExercise: 10}) {
     setup();
-    // Warmup for at least 100ms. Discard result.
-    measureFor(() { this.warmup(); }, 100);
-    // Run the benchmark for at least 2000ms.
-    double result = measureFor(() { this.exercise(); }, 2000);
+    // Run the warmup.
+    measureFor(
+        () { this.warmup(iterations: runsPerWarmup); },
+        minimumWarmupMillis, maxIterations: maxWarmupIterations);
+    // Run the benchmark.
+    double result = measureFor(
+        () {this.exercise(iterations: runsPerExercise); },
+        minimumBenchmarkMillis, maxIterations: maxExerciseIterations);
     teardown();
     return result;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: benchmark_harness
-version: 1.0.4
+version: 1.1.0
 author: Dart Project <johnmccutchan@google.com>
 description: The official Dart project benchmark harness.
 homepage: http://www.dartlang.org

--- a/test/benchmark_harness_test.dart
+++ b/test/benchmark_harness_test.dart
@@ -15,14 +15,51 @@ void main() {
       expect(micros, isPositive);
       expect(benchmark.runCount, isPositive);
     });
+
+    test('can set warmup and excersize iterations and runs per iteration', () {
+      MockBenchmark benchmark = new MockBenchmark();
+      double micros = benchmark.measure(
+          maxWarmupIterations: 5, maxExerciseIterations: 5,
+          runsPerWarmup: 5, runsPerExercise: 5);
+      // 25 total runs from each (5 * 5)
+      expect(benchmark.runCount, 50);
+      expect(benchmark.warmupCount, 5);
+      expect(benchmark.exerciseCount, 5);
+    });
+
+    test('can customize the time a benchmark will run', () {
+      MockBenchmark benchmark100 = new MockBenchmark()
+        ..measure(minimumBenchmarkMillis: 100, minimumWarmupMillis: 100);
+
+      MockBenchmark benchmark500 = new MockBenchmark()
+        ..measure(minimumBenchmarkMillis: 500, minimumWarmupMillis: 500);
+
+      expect(benchmark100.exerciseCount, lessThan(benchmark500.exerciseCount));
+      expect(benchmark100.warmupCount, lessThan(benchmark500.warmupCount));
+    });
   });
 }
 
 class MockBenchmark extends BenchmarkBase {
   int runCount = 0;
+  int warmupCount = 0;
+  int exerciseCount = 0;
 
   MockBenchmark() : super('mock benchmark');
 
+  @override
+  void exercise({int iterations: 10}) {
+    exerciseCount++;
+    super.exercise(iterations: iterations);
+  }
+
+  @override
+  void warmup({int iterations: 1}) {
+    warmupCount++;
+    super.warmup(iterations: iterations);
+  }
+
+  @override
   void run() {
     runCount++;
   }

--- a/test/benchmark_harness_test.dart
+++ b/test/benchmark_harness_test.dart
@@ -19,8 +19,10 @@ void main() {
     test('can set warmup and excersize iterations and runs per iteration', () {
       MockBenchmark benchmark = new MockBenchmark();
       double micros = benchmark.measure(
-          maxWarmupIterations: 5, maxExerciseIterations: 5,
-          runsPerWarmup: 5, runsPerExercise: 5);
+          maxWarmupIterations: 5,
+          maxExerciseIterations: 5,
+          runsPerWarmup: 5,
+          runsPerExercise: 5);
       // 25 total runs from each (5 * 5)
       expect(benchmark.runCount, 50);
       expect(benchmark.warmupCount, 5);


### PR DESCRIPTION
This cl allows you to control the number of times and minimum time that an individual benchmark will run, as well as how many iterations will run per call to `exercise` or `warmup`.
