### PR TITLE
update for the 2.10 dev sdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,28 @@
 language: dart
 
 dart:
-  - dev
+  - preview/raw/2.10.0-0.2-dev
 
 jobs:
   include:
     - stage: analyze_and_format
       name: "Analyze"
-      dart: dev
+      dart: preview/raw/2.10.0-0.2-dev
       os: linux
       script: dartanalyzer --enable-experiment=non-nullable --fatal-warnings --fatal-infos .
     - stage: analyze_and_format
       name: "Format"
-      dart: dev
+      dart: preview/raw/2.10.0-0.2-dev
       os: linux
       script: dartfmt -n --set-exit-if-changed .
     - stage: test
       name: "Vm Tests"
-      dart: dev
+      dart: preview/raw/2.10.0-0.2-dev
       os: linux
       script: pub run --enable-experiment=non-nullable test -p vm
     - stage: test
       name: "Web Tests"
-      dart: dev
+      dart: preview/raw/2.10.0-0.2-dev
       os: linux
       script: pub run --enable-experiment=non-nullable test -p chrome
 
@@ -32,7 +32,7 @@ stages:
 
 # Only building master means that we don't run two builds for each pull request.
 branches:
-  only: [master, null_safety]
+  only: [master]
 
 cache:
   directories:

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+## 1.1.0-nullsafety
+
+- Opt in to null safety.
+
 ## 1.0.6
 
 - Require at least Dart 2.1.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,12 @@
 name: benchmark_harness
-version: 1.0.6-dev
+version: 1.1.0-nullsafety
 author: Dart Team <misc@dartlang.org>
 description: The official Dart project benchmark harness.
 homepage: https://github.com/dart-lang/benchmark_harness
 
 environment:
-  sdk: ">=2.9.0-1 <3.0.0"
+  # This must remain a tight constraint until nnbd is stable
+  sdk: '>=2.10.0-0 <2.10.0'
 
 dev_dependencies:
   build_runner: ^1.1.0
@@ -13,90 +14,59 @@ dev_dependencies:
   path: ^1.1.0
   pedantic: ^1.4.0
   test: ^1.0.0
-
+  
 dependency_overrides:
-  test:
+  async:
+    git: git://github.com/dart-lang/async.git
+  boolean_selector:
+    git: git://github.com/dart-lang/boolean_selector.git
+  charcode:
+    git: git://github.com/dart-lang/charcode.git
+  collection:
+    git: git://github.com/dart-lang/collection.git
+  js:
     git:
-      url: git://github.com/dart-lang/test.git
-      ref: null_safety
-      path: pkgs/test
+      url: git://github.com/dart-lang/sdk.git
+      path: pkg/js
+      ref: 2-10-pkgs
+  matcher:
+    git: git://github.com/dart-lang/matcher.git
+  meta:
+    git:
+      url: git://github.com/dart-lang/sdk.git
+      path: pkg/meta
+      ref: 2-10-pkgs
+  path:
+    git: git://github.com/dart-lang/path.git
+  pedantic:
+    git: git://github.com/dart-lang/pedantic.git
+  pool:
+    git: git://github.com/dart-lang/pool.git
+  source_maps:
+    git: git://github.com/dart-lang/source_maps.git
+  source_map_stack_trace:
+    git: git://github.com/dart-lang/source_map_stack_trace.git
+  source_span:
+    git: git://github.com/dart-lang/source_span.git
+  stack_trace:
+    git: git://github.com/dart-lang/stack_trace.git
+  stream_channel:
+    git: git://github.com/dart-lang/stream_channel.git
+  string_scanner:
+    git: git://github.com/dart-lang/string_scanner.git
+  term_glyph:
+    git: git://github.com/dart-lang/term_glyph.git
   test_api:
     git:
       url: git://github.com/dart-lang/test.git
-      ref: null_safety
       path: pkgs/test_api
   test_core:
     git:
       url: git://github.com/dart-lang/test.git
-      ref: null_safety
       path: pkgs/test_core
-  async:
+  test:
     git:
-      url: git://github.com/dart-lang/async.git
-      ref: null_safety
-  boolean_selector:
-    git:
-      url: git://github.com/dart-lang/boolean_selector.git
-      ref: null_safety
-  charcode:
-    git:
-      url: git://github.com/dart-lang/charcode.git
-      ref: null_safety
-  collection:
-    git:
-      url: git://github.com/dart-lang/collection.git
-      ref: null_safety
-  js:
-    git:
-      url: git://github.com/dart-lang/sdk.git
-      ref: null_safety-pkgs
-      path: pkg/js
-  matcher:
-    git:
-      url: git://github.com/dart-lang/matcher.git
-      ref: null_safety
-  meta:
-    git:
-      url: git://github.com/dart-lang/sdk.git
-      ref: null_safety-pkgs
-      path: pkg/meta
-  path:
-    git:
-      url: git://github.com/dart-lang/path.git
-      ref: null_safety
-  pedantic:
-    git:
-      url: git://github.com/dart-lang/pedantic.git
-      ref: null_safety
-  pool:
-    git:
-      url: git://github.com/dart-lang/pool.git
-      ref: null_safety
-  source_maps:
-    git:
-      url: git://github.com/dart-lang/source_maps.git
-      ref: null_safety
-  source_map_stack_trace:
-    git:
-      url: git://github.com/dart-lang/source_map_stack_trace.git
-      ref: null_safety
-  source_span:
-    git:
-      url: git://github.com/dart-lang/source_span.git
-      ref: null_safety
-  stack_trace:
-    git:
-      url: git://github.com/dart-lang/stack_trace.git
-      ref: null_safety
-  stream_channel:
-    git:
-      url: git://github.com/dart-lang/stream_channel.git
-      ref: null_safety
-  string_scanner:
-    git:
-      url: git://github.com/dart-lang/string_scanner.git
-      ref: null_safety
-  term_glyph:
-    git:
-      url: git://github.com/dart-lang/term_glyph.git
-      ref: null_safety
+      url: git://github.com/dart-lang/test.git
+      path: pkgs/test
+  typed_data:
+    git: git://github.com/dart-lang/typed_data.git


### PR DESCRIPTION
This is in preparation for the actual 2.10 dev sdk release. This package is pulled into the sdk for benchmarking so we need an updated version, but it is not depended on directly by tests.

Once the other packages have landed ill re-run travis here and land (assuming it is green).