### PR TITLE
More up-to-date code with newer versions of Dart  | Slightly Better Documentation

### DIFF
--- a/lib/benchmark_harness.dart
+++ b/lib/benchmark_harness.dart
@@ -1,4 +1,4 @@
 library benchmark_harness;
 
-part 'src/benchmark_base.dart';
-part 'src/score_emitter.dart';
+export 'src/benchmark_base.dart' show BenchmarkBase;
+export 'src/score_emitter.dart' show PrintEmitter, ScoreEmitter;

--- a/lib/src/benchmark_base.dart
+++ b/lib/src/benchmark_base.dart
@@ -1,64 +1,58 @@
 // Copyright 2011 Google Inc. All Rights Reserved.
 
-part of benchmark_harness;
+import 'score_emitter.dart' show PrintEmitter, ScoreEmitter;
 
 class BenchmarkBase {
   final String name;
   final ScoreEmitter emitter;
 
-  // Empty constructor.
   const BenchmarkBase(this.name, {this.emitter = const PrintEmitter()});
 
-  // The benchmark code.
-  // This function is not used, if both [warmup] and [exercise] are overwritten.
+  /// The benchmark code.
+  /// This function is not used, if both [warmup] and [exercise] are
+  /// overwritten.
   void run() {}
 
-  // Runs a short version of the benchmark. By default invokes [run] once.
-  void warmup() {
-    run();
-  }
+  /// Runs a short version of the benchmark. By default invokes [run] once.
+  void warmup() => run();
 
-  // Exercices the benchmark. By default invokes [run] 10 times.
+  /// Exercices the benchmark. By default invokes [run] 10 times.
   void exercise() {
     for (var i = 0; i < 10; i++) {
       run();
     }
   }
 
-  // Not measured setup code executed prior to the benchmark runs.
+  /// **Not measured** setup code executed prior to the benchmark runs.
   void setup() {}
 
-  // Not measures teardown code executed after the benchark runs.
+  /// **Not measures** teardown code executed after the benchark runs.
   void teardown() {}
 
-  // Measures the score for this benchmark by executing it repeately until
-  // time minimum has been reached.
-  static double measureFor(Function f, int minimumMillis) {
-    var minimumMicros = minimumMillis * 1000;
-    var iter = 0;
-    var watch = Stopwatch();
+  /// Measures the score for this benchmark by executing it repeately until
+  /// time minimum has been reached.
+  static double measureFor(Function functionToBeMeasured, int minimumMillis) {
+    final minimumMicros = minimumMillis * 1000, watch = Stopwatch();
+    var iter = 0, elapsed = 0;
     watch.start();
-    var elapsed = 0;
     while (elapsed < minimumMicros) {
-      f();
+      functionToBeMeasured();
       elapsed = watch.elapsedMicroseconds;
       iter++;
     }
     return elapsed / iter;
   }
 
-  // Measures the score for the benchmark and returns it.
+  /// Measures the score for the benchmark and returns it.
   double measure() {
     setup();
     // Warmup for at least 100ms. Discard result.
     measureFor(warmup, 100);
     // Run the benchmark for at least 2000ms.
-    var result = measureFor(exercise, 2000);
+    final result = measureFor(exercise, 2000);
     teardown();
     return result;
   }
 
-  void report() {
-    emitter.emit(name, measure());
-  }
+  void report() => emitter.emit(name, measure());
 }

--- a/lib/src/score_emitter.dart
+++ b/lib/src/score_emitter.dart
@@ -1,6 +1,7 @@
-part of benchmark_harness;
-
 abstract class ScoreEmitter {
+  const ScoreEmitter();
+
+  /// Override this method to report scores.
   void emit(String testName, double value);
 }
 
@@ -8,7 +9,6 @@ class PrintEmitter implements ScoreEmitter {
   const PrintEmitter();
 
   @override
-  void emit(String testName, double value) {
-    print('$testName(RunTime): $value us.');
-  }
+  void emit(String testName, double value) =>
+      print('$testName(RunTime): $value us.');
 }

--- a/test/benchmark_harness_test.dart
+++ b/test/benchmark_harness_test.dart
@@ -4,14 +4,14 @@
 
 library benchmark_harness_test;
 
-import 'package:benchmark_harness/benchmark_harness.dart';
-import 'package:test/test.dart';
+import 'package:test/test.dart' show expect, group, isPositive, test;
+
+import 'package:benchmark_harness/benchmark_harness.dart' show BenchmarkBase;
 
 void main() {
   group('benchmark_harness', () {
     test('run is called', () {
-      var benchmark = MockBenchmark();
-      var micros = benchmark.measure();
+      final benchmark = MockBenchmark(), micros = benchmark.measure();
       expect(micros, isPositive);
       expect(benchmark.runCount, isPositive);
     });
@@ -24,7 +24,5 @@ class MockBenchmark extends BenchmarkBase {
   MockBenchmark() : super('mock benchmark');
 
   @override
-  void run() {
-    runCount++;
-  }
+  void run() => runCount++;
 }

--- a/test/result_emitter_test.dart
+++ b/test/result_emitter_test.dart
@@ -1,20 +1,17 @@
 library result_emitter_test;
 
-import 'package:benchmark_harness/benchmark_harness.dart';
+import 'package:test/test.dart' show equals, expect, group, test;
 
-import 'package:test/test.dart';
+import 'package:benchmark_harness/benchmark_harness.dart'
+    show BenchmarkBase, ScoreEmitter;
 
-void main() {
-  benchmarkHarnessTest();
-}
+void main() => benchmarkHarnessTest();
 
 class MockResultEmitter extends ScoreEmitter {
   int emitCount = 0;
 
   @override
-  void emit(String name, double value) {
-    emitCount++;
-  }
+  void emit(String name, double value) => emitCount++;
 }
 
 // Create a new benchmark which has an emitter.
@@ -33,15 +30,11 @@ class BenchmarkWithResultEmitter extends BenchmarkBase {
 }
 
 void benchmarkHarnessTest() {
-  MockResultEmitter createMockEmitter() {
-    var emitter = MockResultEmitter();
-    return emitter;
-  }
-
   group('ResultEmitter', () {
     test('should be called when emitter is provided', () {
-      var emitter = createMockEmitter();
-      var testBenchmark = BenchmarkWithResultEmitter(emitter);
+      final emitter = MockResultEmitter(),
+          testBenchmark = BenchmarkWithResultEmitter(emitter);
+
       testBenchmark.report();
 
       expect(emitter.emitCount, equals(1));


### PR DESCRIPTION
This is a minor refactoring featuring mostly &mdash; no behavior has changed &mdash;:

- Variables which could be `final` are now `final`.
- The Dart documentation, which was made with comments, now uses `///`, conforming with the Dart docstrings.
- `part` statements have been replaced with `export`s, conforming to the [recommendation on the package layout conventions][no_part_recommendation].
- The changelog file now has upper case letters.


[no_part_recommendation]: https://dart.dev/guides/libraries/create-library-packages#organizing-a-library-package