### PR TITLE
prep for null safety release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ jobs:
     - stage: analyze_and_format
       name: "Analyze"
       os: linux
-      script: dartanalyzer --enable-experiment=non-nullable --fatal-warnings --fatal-infos .
+      script: dartanalyzer --fatal-warnings --fatal-infos .
     - stage: analyze_and_format
       name: "Format"
       os: linux
@@ -16,11 +16,11 @@ jobs:
     - stage: test
       name: "Vm Tests"
       os: linux
-      script: pub run --enable-experiment=non-nullable test -p vm
+      script: pub run test -p vm
     - stage: test
       name: "Web Tests"
       os: linux
-      script: pub run --enable-experiment=non-nullable test -p chrome
+      script: pub run test -p chrome
 
 stages:
   - analyze_and_format

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-## 1.1.0-nullsafety.1
+## 1.1.0-nullsafety.0
 
 - Opt in to null safety.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,4 @@
-## 1.1.0-nullsafety.1-dev
-
-- Allow the 2.10 stable and 2.11.0 dev SDKs.
-
-## 1.1.0-nullsafety
+## 1.1.0-nullsafety.1
 
 - Opt in to null safety.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-## 1.1.0-nullsafety.0
+## 2.0.0-nullsafety.0
 
 - Opt in to null safety.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: benchmark_harness
-version: 1.1.0-nullsafety.0
+version: 2.0.0-nullsafety.0
 author: Dart Team <misc@dartlang.org>
 description: The official Dart project benchmark harness.
 homepage: https://github.com/dart-lang/benchmark_harness

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,6 @@ description: The official Dart project benchmark harness.
 homepage: https://github.com/dart-lang/benchmark_harness
 
 environment:
-  # This must remain a tight constraint until nnbd is stable
   sdk: '>=2.12.0-0 <3.0.0'
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,72 +1,16 @@
 name: benchmark_harness
-version: 1.1.0-nullsafety.1-dev
+version: 1.1.0-nullsafety.0
 author: Dart Team <misc@dartlang.org>
 description: The official Dart project benchmark harness.
 homepage: https://github.com/dart-lang/benchmark_harness
 
 environment:
   # This must remain a tight constraint until nnbd is stable
-  sdk: '>=2.10.0-0 <2.11.0'
+  sdk: '>=2.12.0-0 <3.0.0'
 
 dev_dependencies:
   build_runner: ^1.1.0
   build_web_compilers: '>=1.0.0 <3.0.0'
-  path: ^1.1.0
-  pedantic: ^1.4.0
-  test: ^1.0.0
-
-dependency_overrides:
-  async:
-    git: git://github.com/dart-lang/async.git
-  boolean_selector:
-    git: git://github.com/dart-lang/boolean_selector.git
-  charcode:
-    git: git://github.com/dart-lang/charcode.git
-  collection:
-    git: git://github.com/dart-lang/collection.git
-  js:
-    git:
-      url: git://github.com/dart-lang/sdk.git
-      path: pkg/js
-      ref: 2-10-pkgs
-  matcher:
-    git: git://github.com/dart-lang/matcher.git
-  meta:
-    git:
-      url: git://github.com/dart-lang/sdk.git
-      path: pkg/meta
-      ref: 2-10-pkgs
-  path:
-    git: git://github.com/dart-lang/path.git
-  pedantic:
-    git: git://github.com/dart-lang/pedantic.git
-  pool:
-    git: git://github.com/dart-lang/pool.git
-  source_maps:
-    git: git://github.com/dart-lang/source_maps.git
-  source_map_stack_trace:
-    git: git://github.com/dart-lang/source_map_stack_trace.git
-  source_span:
-    git: git://github.com/dart-lang/source_span.git
-  stack_trace:
-    git: git://github.com/dart-lang/stack_trace.git
-  stream_channel:
-    git: git://github.com/dart-lang/stream_channel.git
-  string_scanner:
-    git: git://github.com/dart-lang/string_scanner.git
-  term_glyph:
-    git: git://github.com/dart-lang/term_glyph.git
-  test_api:
-    git:
-      url: git://github.com/dart-lang/test.git
-      path: pkgs/test_api
-  test_core:
-    git:
-      url: git://github.com/dart-lang/test.git
-      path: pkgs/test_core
-  test:
-    git:
-      url: git://github.com/dart-lang/test.git
-      path: pkgs/test
-  typed_data:
-    git: git://github.com/dart-lang/typed_data.git
+  path: ^1.8.0-nullsafety
+  pedantic: ^1.10.0-nullsafety
+  test: ^1.16.0-nullsafety


### PR DESCRIPTION
Previous versions were not published, so publishing as `-nullsafety.0`.