### PR TITLE
Remove "Learning more" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 
 The Dart project benchmark harness is the recommended starting point when building a benchmark for Dart.
 
-## Learning more
-
-You can read more about [Benchmarking the Dart VM](https://www.dartlang.org/articles/server/benchmarking/).
-
 ## Interpreting Results
 
 By default, the reported runtime is not for a single call to `run()`, but for


### PR DESCRIPTION
The link is dead and there currently is not a great alternative focused on this package, at least not anything offering more than what the README has currently.

Perhaps we can explore adding further examples/walkthroughs on site-www, but I thought removing the dead link could prevent confusion for now.