### PR TITLE
Reduce measurement overhead by allowing some degree of measurement jitter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.2.1
+
+- Improve convergence speed of `BenchmarkBase` measuring algorithm by allowing
+some degree of measuring jitter.
+
 ## 2.2.0
 
 - Change measuring algorithm in `BenchmarkBase` to avoid calling stopwatch

--- a/lib/src/benchmark_base.dart
+++ b/lib/src/benchmark_base.dart
@@ -39,6 +39,10 @@ class BenchmarkBase {
   /// to reach [minimumMillis].
   static _Measurement _measureForImpl(void Function() f, int minimumMillis) {
     final minimumMicros = minimumMillis * 1000;
+    // If running a long measurement permit some amount of measurment jitter
+    // to avoid discarding results that are almost good, but not quite there.
+    final allowedJitter =
+        minimumMillis < 1000 ? 0 : (minimumMicros * 0.1).floor();
     var iter = 2;
     final watch = Stopwatch()..start();
     while (true) {
@@ -48,7 +52,7 @@ class BenchmarkBase {
       }
       final elapsed = watch.elapsedMicroseconds;
       final measurement = _Measurement(elapsed, iter);
-      if (measurement.elapsedMicros >= minimumMicros) {
+      if (measurement.elapsedMicros >= (minimumMicros - allowedJitter)) {
         return measurement;
       }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: benchmark_harness
-version: 2.2.0
+version: 2.2.1
 description: The official Dart project benchmark harness.
 repository: https://github.com/dart-lang/benchmark_harness
 


### PR DESCRIPTION
After rolling #38 into Dart SDK we have started to see timeouts on some of the benchmarks. 

I have investigated and I can see that we have increase runtime of a few benchmarks by around ~80%.

This change reduces the overhead to around ~30%.