### PR TITLE
add a publishing workflow action to dart-lang/benchmark_harness

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,4 +11,4 @@ on:
 jobs:
   publish:
     if: ${{ github.repository_owner == 'dart-lang' }}
-    uses: devoncarew/firehose/.github/workflows/publish.yaml@main
+    uses: dart-lang/ecosystem/.github/workflows/publish.yaml@main

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,14 @@
+# A CI configuration to auto-publish pub packages.
+
+name: Publish
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    tags: [ 'v[0-9]+.[0-9]+.[0-9]+*' ]
+
+jobs:
+  publish:
+    if: github.repository_owner == 'dart-lang'
+    uses: devoncarew/firehose/.github/workflows/publish.yaml@main

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,11 +4,11 @@ name: Publish
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
   push:
     tags: [ 'v[0-9]+.[0-9]+.[0-9]+*' ]
 
 jobs:
   publish:
-    if: github.repository_owner == 'dart-lang'
+    if: ${{ github.repository_owner == 'dart-lang' }}
     uses: devoncarew/firehose/.github/workflows/publish.yaml@main

--- a/README.md
+++ b/README.md
@@ -120,3 +120,22 @@ This is the average amount of time it takes to run `run()` 10 times for
 This package is carefully curated by the Dart team to exact specifications.
 Please open an issue with any proposed changes, before submitting a Pull
 Request.
+
+## Contributions, PRs, and publishing
+
+When contributing to this repo:
+
+- if the package version is a stable semver version (`x.y.z`), the latest
+  changes have been published to pub. Please add a new changelog section for
+  your change, rev the service portion of the version, append `-dev`, and update
+  the pubspec version to agree with the new version
+- if the package version ends in `-dev`, the latest changes are unpublished;
+  please add a new changelog entry for your change in the most recent section.
+  When we decide to publish the latest changes we'll drop the `-dev` suffix
+  from the package version
+- for PRs, the `Publish` bot will perform basic validation of the info in the
+  pubspec.yaml and CHANGELOG.md files
+- when the PR is merged into the main branch, if the change includes reving to
+  a new stable version, a repo maintainer will tag that commit with the pubspec
+  version (e.g., `v1.2.3`); that tag event will trigger the `Publish` bot to
+  publish a new version of the package to pub.dev

--- a/README.md
+++ b/README.md
@@ -118,10 +118,10 @@ This is the average amount of time it takes to run `run()` 10 times for
 ### Contributions
 
 This package is carefully curated by the Dart team to exact specifications.
-Please open an issue with any proposed changes, before submitting a Pull
-Request.
+Please open an issue with any proposed changes before submitting a pull
+request.
 
-## Contributions, PRs, and publishing
+## PRs and publishing
 
 When contributing to this repo:
 

--- a/README.md
+++ b/README.md
@@ -121,21 +121,7 @@ This package is carefully curated by the Dart team to exact specifications.
 Please open an issue with any proposed changes before submitting a pull
 request.
 
-## PRs and publishing
+## Publishing automation
 
-When contributing to this repo:
-
-- if the package version is a stable semver version (`x.y.z`), the latest
-  changes have been published to pub. Please add a new changelog section for
-  your change, rev the service portion of the version, append `-dev`, and update
-  the pubspec version to agree with the new version
-- if the package version ends in `-dev`, the latest changes are unpublished;
-  please add a new changelog entry for your change in the most recent section.
-  When we decide to publish the latest changes we'll drop the `-dev` suffix
-  from the package version
-- for PRs, the `Publish` bot will perform basic validation of the info in the
-  pubspec.yaml and CHANGELOG.md files
-- when the PR is merged into the main branch, if the change includes reving to
-  a new stable version, a repo maintainer will tag that commit with the pubspec
-  version (e.g., `v1.2.3`); that tag event will trigger the `Publish` bot to
-  publish a new version of the package to pub.dev
+For information about our publishing automation and release process, see
+https://github.com/dart-lang/ecosystem/wiki/Publishing-automation.


### PR DESCRIPTION
This PR adds a publishing workflow action to this repo. We'd like to move to having more automation around publishing packages; the workflow's described a bit in the update to the readme in this PR. Briefly:

- most changes (PR) will need changelog entries
- changes which we don't intend to publish right away get added to the changelog using a `-dev` version
- changes which we do want to publish get added as a new stable semver version
- after the change hits the master branch, we trigger publishing by tagging the commit with the new pubspec version (i.e., `v2.2.1`)
